### PR TITLE
Fixed Process' MainWindowTitle to reflect Slack v2.1.0 value

### DIFF
--- a/HeadlessSlacker/Slack.cs
+++ b/HeadlessSlacker/Slack.cs
@@ -99,7 +99,7 @@ namespace HeadlessSlacker
 
         IntPtr? GetWindowHandleOrNull()
         {
-            var slackProcess = Process.GetProcesses().FirstOrDefault(x => x.MainWindowTitle.EndsWith("- Slack"));
+            var slackProcess = Process.GetProcesses().FirstOrDefault(x => x.MainWindowTitle.StartsWith("Slack - "));
             if (slackProcess == null)
                 return null;
 


### PR DESCRIPTION
Noticed that Slack v2.1.0 window title changed. Now it is "Slack - " + TEAMNAME, so fixed so it will get the right process handle to inject the "hide taskbar icon" button. 
